### PR TITLE
カートアイテムコントローラーとアイテムビューの修正

### DIFF
--- a/app/controllers/cart_items_controller.rb
+++ b/app/controllers/cart_items_controller.rb
@@ -1,6 +1,7 @@
 class CartItemsController < ApplicationController
   before_action :find_cart_item, only:[:update, :destroy]
-  
+  before_action :authenticate_customer!
+
   def create
     #old item に current_customerのcart_itemsの中からitem_idがparams(item/showで作成したcart_item)のitem_idと同じものを探して入力
     @old_item = current_customer.cart_items.find_by(item_id: params[:cart_item][:item_id])
@@ -11,39 +12,39 @@ class CartItemsController < ApplicationController
       @old_item.save
     #old_itemが見つからなかった場合
     else
-      @cart_item = CartItem.new(cart_item_params)
+      @cart_item = current_customer.cart_items.new(cart_item_params)
       @cart_item.save
     end
     redirect_to cart_items_path
   end
-  
+
   def index
     @cart_items = current_customer.cart_items
   end
-  
+
   def destroy
     @cart_item.destroy
     redirect_back(fallback_location: root_path)
   end
-  
+
   def destroy_all
     cart_items = current_customer.cart_items
     cart_items.destroy_all
     redirect_to items_path
   end
-  
+
   def update
     @cart_item.update(cart_item_params)
     redirect_back(fallback_location: root_path)
 
   end
-  
-  
-  private 
+
+
+  private
   def cart_item_params
     params.require(:cart_item).permit(:customer_id, :item_id, :amount)
   end
-  
+
   def find_cart_item
     @cart_item = current_customer.cart_items.find(params[:id])
   end

--- a/app/views/admins/customers/index.html.erb
+++ b/app/views/admins/customers/index.html.erb
@@ -1,10 +1,10 @@
 <main>
 <container>
-    <div class="row">
-        <div class="col-xs-offset-1">
-        <h1>会員一覧</h1>
-        </div>
+<div class="row">
+    <div class="col-xs-offset-1">
+    <h1>会員一覧</h1>
     </div>
+</div>
 
 <div class="row">
 <div class="col-xs-6 col-xs-offset-3">
@@ -31,10 +31,9 @@
             <td>有効</td>
             <% else %>
             <td>退会済み</td>
-            <td><%= customer.is_deleted %></td>
             <% end %>
         </tr>
-            <% end %>
+        <% end %>
     </tbody>
 </table>
 </div>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -15,7 +15,7 @@
         </div>
         <%= form_with model: @cart_item, url: cart_items_path, local:true do |f| %>
           <%= f.hidden_field :item_id, :value => @sweet_item.id %>
-          <%= f.hidden_field :customer_id, :value => current_customer.id %>
+         
           <%= f.number_field :amount, placeholder: "個数選択", min:1, max: 10 %>
           <%= f.submit "カートに入れる", class: 'btn btn-primary' %>
         <% end %>


### PR DESCRIPTION
ログインしていない状態で、商品の詳細画面まで見れるようにしました。
カートに行こうとすると登録画面にいきます。